### PR TITLE
Adding user to the parameters. The 'user' setting at the root of mara…

### DIFF
--- a/src/tasks/dockerDeploy/acs-dcos/serviceparser.py
+++ b/src/tasks/dockerDeploy/acs-dcos/serviceparser.py
@@ -164,7 +164,7 @@ class Parser(object):
         """
         if key in self.service_info:
             user = self.service_info[key]
-            self.app_json['user'] = user
+            self._append_parameters_key_value('user', user)
 
     def _parse_working_dir(self, key):
         """

--- a/src/tasks/dockerDeploy/acs-dcos/test_serviceparser.py
+++ b/src/tasks/dockerDeploy/acs-dcos/test_serviceparser.py
@@ -293,7 +293,7 @@ class ServiceParserTests(unittest.TestCase):
         self.assertEquals({}, p.app_json)
 
     def test_parse_user(self):
-        expected = { 'user': 'admin' }
+        expected = {'container': {'docker': {'parameters': [{'key': 'user', 'value': 'admin'}]}}}
         p = serviceparser.Parser('groupname', 'myservice', {'user': 'admin'})
         p._parse_user('user')
         self.assertEquals(expected, p.app_json)


### PR DESCRIPTION
…thon.json means the  user that runs the tasks.