### PR TITLE
Only log errors when we are deploying new services; don't log errors …

### DIFF
--- a/src/tasks/dockerDeploy/acs-dcos/dockercomposeparser.py
+++ b/src/tasks/dockerDeploy/acs-dcos/dockercomposeparser.py
@@ -451,14 +451,14 @@ class DockerComposeParser(object):
 
             scale_factor = float(self.minimum_health_capacity)/100
             logging.info('Scale deployment "%s" by factor %s', existing_group_id, scale_factor)
-            self.marathon_helper.scale_group(existing_group_id, scale_factor)
+            self.marathon_helper.scale_group(existing_group_id, scale_factor, log_failures=False)
 
             logging.info('Update deployment "%s" with new instance counts', marathon_json['id'])
             self.marathon_helper.update_group(marathon_json)
 
             # Scale the existing deployment instances to 0
             logging.info('Scale deployment "%s" by factor %s', existing_group_id, 0)
-            self.marathon_helper.scale_group(existing_group_id, 0)
+            self.marathon_helper.scale_group(existing_group_id, 0, log_failures=False)
 
             # Scale up new deployment instances to target instance count
             for app in new_deployment_json['apps']:

--- a/src/tasks/dockerDeploy/acs-dcos/marathon.py
+++ b/src/tasks/dockerDeploy/acs-dcos/marathon.py
@@ -178,13 +178,13 @@ class Marathon(object):
         response = self.get_request('groups/{}'.format(group_id)).json()
         return response
 
-    def scale_group(self, group_id, scale_factor):
+    def scale_group(self, group_id, scale_factor, log_failures=True):
         """
         Scales the group for provided scale_factor
         """
         start_timestamp = time.time()
         response = self.put_request('groups/{}'.format(group_id), json={'scaleBy': scale_factor})
-        self._wait_for_deployment_complete(response, start_timestamp)
+        self._wait_for_deployment_complete(response, start_timestamp, log_failures)
         return response.json()
 
     def is_group_id_unique(self, group_id):
@@ -199,7 +199,7 @@ class Marathon(object):
 
         return False
 
-    def _wait_for_deployment_complete(self, deployment_response, start_timestamp):
+    def _wait_for_deployment_complete(self, deployment_response, start_timestamp, log_failures=True):
         """
         Waits for deployment to Marathon to complete. We start an instance of
         DeploymentMonitor that streams events from Marathon endpoint and monitors when

--- a/src/tasks/dockerDeploy/acs-dcos/marathon_deployments.py
+++ b/src/tasks/dockerDeploy/acs-dcos/marathon_deployments.py
@@ -148,7 +148,8 @@ class DeploymentMonitor(object):
     Monitors deployment of apps to Marathon using their
     app IDs
     """
-    def __init__(self, marathon, app_ids, deployment_id):
+    def __init__(self, marathon, app_ids, deployment_id, log_failures=True):
+        self._log_failures = log_failures
         self._marathon = marathon
         self._deployment_succeeded = False
         self._app_ids = app_ids
@@ -189,7 +190,7 @@ class DeploymentMonitor(object):
         if event.is_status_update() or event.is_app_terminated():
             if event.app_id() in self._app_ids:
                 logging.info(event.status())
-                if event.is_task_failed() or event.is_task_killed():
+                if event.is_task_failed() or event.is_task_killed() and self._log_failures:
                     self._log_stderr(event)
         elif event.is_deployment_succeeded():
             if self._deployment_id == event.data['id']:


### PR DESCRIPTION
…if we are scaling old services down.