### PR TITLE
Ignore the events we can’t parse (i.e. json.loads fails).

### DIFF
--- a/src/tasks/dockerDeploy/acs-dcos/marathon_deployments.py
+++ b/src/tasks/dockerDeploy/acs-dcos/marathon_deployments.py
@@ -215,5 +215,10 @@ class DeploymentMonitor(object):
         for msg in messages:
             if self.stopped:
                 break
-            event = MarathonEvent(json.loads(msg.data))
+            try:
+                json_data = json.loads(msg.data)
+            except ValueError:
+                logging.debug('Failed to parse event: %s', msg.data)
+                continue
+            event = MarathonEvent(json_data)
             yield event


### PR DESCRIPTION
I saw json.loads fail once, however I couldn't reproduce it again. 